### PR TITLE
ipsw: fix smallest edge case of the century

### DIFF
--- a/ipsw_parser/ipsw.py
+++ b/ipsw_parser/ipsw.py
@@ -30,7 +30,7 @@ class IPSW:
     def __init__(self, archive: zipfile.ZipFile):
         self.archive = archive
         self._logger = logging.getLogger(__file__)
-        self.build_manifest = BuildManifest(self, self.archive.read('BuildManifest.plist'))
+        self.build_manifest = BuildManifest(self, self.archive.read(next(f for f in self.archive.namelist() if f.startswith('BuildManifest') and f.endswith('.plist'))))
 
     @cached_property
     def restore_version(self) -> bytes:


### PR DESCRIPTION
For some reason, the iOS (iPhone OS?) 3.0 IPSW for the iPhone 2G/3G contains a build manifest named "BuildManifesto.plist" rather than "BuildManifest.plist". This may exist across other IPSWs, but those are the only occurences that I know of. This commit fixes parsing that manifest.
Source: https://x.com/_m1sta/status/1392199051165196290?s=20