### PR TITLE
build_identity: Add `-o` to 'dyld split' in `extract`

### DIFF
--- a/ipsw_parser/build_identity.py
+++ b/ipsw_parser/build_identity.py
@@ -155,4 +155,4 @@ class BuildIdentity(UserDict):
                 continue
 
             logger.info(f'splitting DSC: {dsc}')
-            ipsw('dyld', 'split', dsc, output)
+            ipsw('dyld', 'split', dsc, '-o', output)


### PR DESCRIPTION
 Fix error caused by no passing `-o` parameter

 plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
Command line: | /usr/local/bin/ipsw dyld split extracted/iPhone16,2_17.3.1_21D61_Restore/System/Cryptexes/OS/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e extracted/iPhone16,2_17.3.1_21D61_Restore
Stderr:       | Usage:
              |   ipsw dyld split <DSC> [flags]