### PR TITLE
requirements: pyimg4>=0.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ click
 coloredlogs
 cached_property
 plumbum
-pyimg4>=0.7
+pyimg4>=0.8.5


### PR DESCRIPTION
 PyIMG4 0.8.5 fixes critical issues that can prevent restores from succeeding, so I'm bumping the minimum version required.
 
 If possible, could a new release be pushed with this change as well?