### PR TITLE
img4: Add support for NonceSlot parameters

### DIFF
--- a/ipsw_parser/img4.py
+++ b/ipsw_parser/img4.py
@@ -1,7 +1,6 @@
 import logging
 
-import pyimg4
-from pyimg4 import IM4P
+from pyimg4 import IM4P, IM4R, IMG4, RestoreProperty
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +131,7 @@ def stitch_component(name: str, im4p_data: bytes, tss):
 
     im4r = None
     if tbm_dict is not None:
-        im4r = pyimg4.IM4R()
+        im4r = IM4R()
         for key in tbm_dict.keys():
-            im4r.add_property(pyimg4.RestoreProperty(fourcc=key, value=tbm_dict[key]))
-    return pyimg4.IMG4(im4p=im4p, im4m=tss.ap_img4_ticket, im4r=im4r).output()
+            im4r.add_property(RestoreProperty(fourcc=key, value=tbm_dict[key]))
+    return IMG4(im4p=im4p, im4m=tss.ap_img4_ticket, im4r=im4r).output()

--- a/ipsw_parser/img4.py
+++ b/ipsw_parser/img4.py
@@ -132,6 +132,16 @@ def stitch_component(name: str, im4p_data: bytes, tss):
     im4r = None
     if tbm_dict is not None:
         im4r = IM4R()
+        if tss.get('RequiresNonceSlot', False) and name in ('SEP', 'SepStage1', 'LLB'):
+            if name in ('SEP', 'SepStage1'):
+                im4r.add_property(
+                    RestoreProperty(fourcc='snid', value=tss.get('SepNonceSlotID', 2))
+                )
+            else:
+                im4r.add_property(
+                    RestoreProperty(fourcc='anid', value=tss.get('ApNonceSlotID', 0))
+                )
+
         for key in tbm_dict.keys():
             im4r.add_property(RestoreProperty(fourcc=key, value=tbm_dict[key]))
     return IMG4(im4p=im4p, im4m=tss.ap_img4_ticket, im4r=im4r).output()


### PR DESCRIPTION
Adds support for NonceSlot parameters, which are used in the iPhone 16's restore process.

Based off of [`idevicerestore`'s implementation](https://github.com/libimobiledevice/idevicerestore/blob/bb5591d690a057fbc6533df2617189005ea95f40/src/img4.c#L507-L549).

Not tested.